### PR TITLE
signed webhooks + automatically assign to activejobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Intercom App
 
 Intercom Application Rails engine and generator
 
-*Note this SDK is in beta version and still needs a lot of improvements.
-We advise you to use it only if you feel you can help contributing and fix issues when you find them*
+*Note this SDK is in beta version and still needs a lot of improvements. We advise you to use it only if you feel you can help contributing and fix issues when you find them*
 
 Description
 -----------
@@ -101,7 +100,7 @@ The `install` generator places your App credentials directly into the intercom_a
 ```ruby
 IntercomApp.configure do |config|
   config.api_key = ENV['INTERCOM_CLIENT_APP_KEY']
-  config.secret = ENV['INTERCOM_CLIENT_APP_SECRET']
+  config.app_secret = ENV['INTERCOM_CLIENT_APP_SECRET']
   config.oauth_modal = false
 end
 ```
@@ -115,12 +114,14 @@ You can add your webhooks subscriptions to the `IntercomApp.config`. Subscriptio
 IntercomApp.configure do |config|
   config.webhooks = [
     {topics: ['users'], url: 'https://my-intercom-app.com/webhooks/users'},
-    {topics: ['conversation.user.created', 'conversation.user.replied'], url: 'https://my-intercom-app.com/webhooks/conversations'}
+    {topics: ['conversation.user.created', 'conversation.user.replied'], url: 'https://my-intercom-app.com/webhooks/conversations'},
+    {topics: ['event.created'], url: 'https://my-intercom-app.com/webhooks/conversations', metadata: { event_names: events } }
   ]
 end
 ```
 
 **Important** You will need to request the `manage_webhooks` permissions from Intercom to receive webhooks from Intercom.
+
 
 Connect to the Intercom API
 ----------------------

--- a/app/controllers/intercom_app/webhooks_controller.rb
+++ b/app/controllers/intercom_app/webhooks_controller.rb
@@ -1,0 +1,33 @@
+module IntercomApp
+  class WebhooksController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    include IntercomApp::WebhookVerification
+
+    class IntercomApp::MissingWebhookJobDeclarationError < StandardError; end
+
+    def receive
+      webhook_job_klass.perform_later({app_id: app_id, webhook: webhook_params.to_h})
+      head :no_content
+    end
+
+    private
+
+    def webhook_params
+      params.except(:controller, :action, :type)
+    end
+
+    def webhook_job_klass
+      "#{webhook_type.sub('.','_').classify}Job".safe_constantize or raise IntercomApp::MissingWebhookJobDeclarationError
+    end
+
+    def webhook_type
+      params[:type]
+    end
+
+    def app_id
+      params[:app_id]
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,8 @@ IntercomApp::Engine.routes.draw do
     get 'auth/intercom/callback' => :callback
     get 'logout' => :destroy, :as => :logout
   end
+
+  namespace :webhooks do
+    post ':type' => :receive
+  end
 end

--- a/intercom-app.gemspec
+++ b/intercom-app.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = IntercomApp::VERSION
   s.date        = '2016-07-04'
   s.summary     = "Intercom.io ruby application boilerplate"
-  s.description = "This gem helps you to get started with your Intercom.io app"
+  s.description = "This gem helps you to get started with your Intercom app"
   s.authors     = ["Kevin Antoine"]
   s.email       = 'kevin.antoine@intercom.io'
   s.files       = ["lib/intercom-app.rb"]
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_runtime_dependency 'intercom', '~>3.5'
+  s.add_runtime_dependency 'intercom', '~> 3.5'
   s.add_runtime_dependency 'omniauth-intercom', '~>0.1'
 
   s.add_development_dependency 'rails', '~> 4.2'

--- a/lib/generators/intercom_app/install/install_generator.rb
+++ b/lib/generators/intercom_app/install/install_generator.rb
@@ -1,20 +1,25 @@
 require 'rails/generators/base'
 require 'rails/generators/active_record'
+require 'intercom-app/hub_secret_generator'
+
 
 module IntercomApp
   module Generators
     class InstallGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
+      include IntercomApp::Utils
       source_root File.expand_path('../templates', __FILE__)
 
       class_option :app_key, type: :string, default: '<app_key>'
       class_option :app_secret, type: :string, default: '<app_secret>'
       class_option :oauth_modal, type: :boolean, default: false
+      class_option :hub_secret, type: :string
 
       def create_intercom_app_initializer
         @app_key = options['app_key']
         @app_secret = options['app_secret']
         @oauth_modal = options['oauth_modal']
+        @hub_secret = generate_signature
 
         template 'intercom_app.rb', 'config/initializers/intercom_app.rb'
       end
@@ -35,9 +40,18 @@ module IntercomApp
         copy_file 'intercom_session_repository.rb', 'config/initializers/intercom_session_repository.rb'
       end
 
-
       def mount_engine
         route "mount IntercomApp::Engine, at: '/'"
+      end
+
+      private
+
+      def generate_hub_secret
+        if yes?("In order to increase the safety of your app, would you like your webhooks to be automatically signed?(y/n)")
+          return random_hub_secret
+        else
+          return ''
+        end
       end
 
     end

--- a/lib/generators/intercom_app/install/templates/intercom_app.rb
+++ b/lib/generators/intercom_app/install/templates/intercom_app.rb
@@ -1,5 +1,6 @@
 IntercomApp.configure do |config|
   config.app_key = "<%= @app_key %>"
   config.app_secret = "<%= @app_secret %>"
+  config.hub_secret = "<%= @hub_secret %>"
   config.oauth_modal = <%= @oauth_modal %>
 end

--- a/lib/intercom-app.rb
+++ b/lib/intercom-app.rb
@@ -2,11 +2,13 @@ require 'intercom-app/version'
 require 'intercom-app/app'
 require 'intercom-app/configuration'
 require 'intercom-app/engine'
+require 'intercom-app/hub_secret_generator'
 require 'intercom-app/in_memory_session_store'
 require 'intercom-app/login_protection'
 require 'intercom-app/session_repository'
 require 'intercom-app/session_storage'
 require 'intercom-app/sessions_concern'
+require 'intercom-app/webhook_verification'
 require 'intercom-app/webhooks_manager'
 
 # deps

--- a/lib/intercom-app/configuration.rb
+++ b/lib/intercom-app/configuration.rb
@@ -5,6 +5,7 @@ module IntercomApp
     attr_accessor :app_secret
     attr_accessor :oauth_modal
     attr_accessor :webhooks
+    attr_accessor :hub_secret
 
     def initialize
     end

--- a/lib/intercom-app/hub_secret_generator.rb
+++ b/lib/intercom-app/hub_secret_generator.rb
@@ -1,0 +1,14 @@
+require 'digest/sha1'
+
+module IntercomApp
+  module Utils
+
+    def random_string
+      (0...20).map { (65 + rand(26)).chr }.join
+    end
+
+    def random_hub_secret
+      Digest::SHA1.hexdigest random_string
+    end
+  end
+end

--- a/lib/intercom-app/webhook_verification.rb
+++ b/lib/intercom-app/webhook_verification.rb
@@ -1,0 +1,26 @@
+module IntercomApp
+  module WebhookVerification
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :verify_request
+    end
+
+    private
+    def verify_request
+      body = request.body.read
+      return head :unauthorized unless hmac_valid?(body)
+    end
+
+    def hmac_valid?(payload_body)
+      secret = IntercomApp.configuration.hub_secret
+      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, payload_body)
+      Rack::Utils.secure_compare(signature, intercom_hmac)
+    end
+
+    def intercom_hmac
+      request.headers['X-Hub-Signature']
+    end
+
+  end
+end

--- a/lib/intercom-app/webhooks_manager.rb
+++ b/lib/intercom-app/webhooks_manager.rb
@@ -1,29 +1,28 @@
 module IntercomApp
   class WebhooksManager
     class CreationFailed < StandardError; end
-
     def initialize(params)
       @intercom_token = params[:intercom_token]
     end
 
-    def create_webhooks
+    def create_webhooks_subscriptions
       return unless required_webhooks.present?
       required_webhooks.each do |webhook|
-        create_webhook(webhook) unless webhook_exists?(webhook[:topics])
+        create_webhook_subscription(webhook) unless webhook_subscription_exists?(webhook[:topics])
       end
     end
 
-    def destroy_webhooks
+    def destroy_webhooks_subscriptions
       intercom_client.subscriptions.all.each do |webhook|
         intercom_client.subscriptions.delete(webhook.id) if is_required_webhook?(webhook)
       end
 
-      @current_webhooks = nil
+      @current_webhooks_subscriptions = nil
     end
 
-    def recreate_webhooks!
-      destroy_webhooks
-      create_webhooks
+    def recreate_webhooks_subscriptions!
+      destroy_webhooks_subscriptions
+      create_webhooks_subscriptions
     end
 
     private
@@ -40,16 +39,22 @@ module IntercomApp
       required_webhooks.map{ |w| w[:url] }.include? webhook.url
     end
 
-    def create_webhook(attributes)
+    def create_webhook_subscription(attributes)
+      add_hub_secret_to_subscription(attributes)
       webhook = intercom_client.subscriptions.create(attributes)
     end
 
-    def webhook_exists?(topics)
-      current_webhooks[topics]
+    def webhook_subscription_exists?(topics)
+      current_webhooks_subscriptions[topics]
     end
 
-    def current_webhooks
-      @current_webhooks ||= intercom_client.subscriptions.all.index_by(&:topics)
+    def current_webhooks_subscriptions
+      @current_webhooks_subscriptions ||= intercom_client.subscriptions.all.index_by(&:topics)
     end
+
+    def add_hub_secret_to_subscription(attributes)
+      attributes[:hub_secret] = IntercomApp.configuration.hub_secret if IntercomApp.configuration.hub_secret.present?
+    end
+
   end
 end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -10,6 +10,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     provide_existing_application_file
     provide_existing_routes_file
     provide_existing_application_controller
+    IntercomApp::Generators::InstallGenerator.any_instance.stubs(:generate_signature).returns('')
   end
 
   test "creates the IntercomApp initializer" do
@@ -18,6 +19,14 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.app_key = "<app_key>"', intercom_app
       assert_match 'config.app_secret = "<app_secret>"', intercom_app
       assert_match 'config.oauth_modal = false', intercom_app
+    end
+  end
+
+  test "creates the IntercomApp initializer with signed webhooks" do
+    IntercomApp::Generators::InstallGenerator.any_instance.stubs(:generate_signature).returns("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed")
+    run_generator
+    assert_file "config/initializers/intercom_app.rb" do |intercom_app|
+      assert_match 'config.hub_secret = "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"', intercom_app
     end
   end
 
@@ -30,7 +39,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "creats and injects into omniauth initializer" do
+  test "creates and injects into omniauth initializer" do
     run_generator
     assert_file "config/initializers/omniauth.rb" do |omniauth|
       assert_match "provider :intercom", omniauth

--- a/test/intercom_ruby_app_example/Gemfile.lock
+++ b/test/intercom_ruby_app_example/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../..
   specs:
     intercom-app (0.1.1)
-      intercom (~> 3.5)
+      intercom (= 3.5.2)
       omniauth-intercom (~> 0.1)
 
 GEM


### PR DESCRIPTION
- add an option in the generator to automatically sign and verify webhooks in the lib
- webhook controller has only one method which calls a job following a convention : 
- 'conversations.user.replied' webhook calls ConversationUserRepliedJob.perform